### PR TITLE
Client-side APIs for RSA Blind Signatures

### DIFF
--- a/Sources/_CryptoExtras/RSA/RSA+BlindSigning.swift
+++ b/Sources/_CryptoExtras/RSA/RSA+BlindSigning.swift
@@ -332,8 +332,7 @@ extension _RSA.BlindSigning.PrivateKey {
     }
 }
 
-
-extension _RSA.BlindSigning {
+extension _RSA.BlindSigning.PublicKey {
     /// Prepare a message to be signed using the blind signing protocol.
     ///
     /// - Parameter message: The message to be signed.
@@ -341,22 +340,15 @@ extension _RSA.BlindSigning {
     /// - Returns: A preprared mesage, modified according to the parameters provided.
     ///
     /// - Seealso: [RFC 9474: Prepare](https://www.rfc-editor.org/rfc/rfc9474.html#name-prepare).
-    ///
-    /// - TODO: I think this should probably just be moved to PublicKey to keep the API cleaner.
-    public static func prepare<D: DataProtocol, H: HashFunction>(
-        _ message: D,
-        parameters: _RSA.BlindSigning.Parameters<H> = .RSABSSA_SHA384_PSS_Randomized
-    ) -> _RSA.BlindSigning.PreparedMessage {
-        switch parameters.preparation {
+    public func prepare<D: DataProtocol>(_ message: D) -> _RSA.BlindSigning.PreparedMessage {
+        switch self.parameters.preparation {
         case .identity:
-            return PreparedMessage(rawRepresentation: Data(message))
+            return _RSA.BlindSigning.PreparedMessage(rawRepresentation: Data(message))
         case .randomized:
-            return PreparedMessage(rawRepresentation: Data(SystemRandomNumberGenerator.randomBytes(count: 32)) + message)
+            return _RSA.BlindSigning.PreparedMessage(rawRepresentation: Data(SystemRandomNumberGenerator.randomBytes(count: 32)) + message)
         }
     }
-}
 
-extension _RSA.BlindSigning.PublicKey {
     /// Blind a message to be signed by the server using the blind signing protocol.
     ///
     /// - Parameter message: The message to be signed.

--- a/Sources/_CryptoExtras/RSA/RSA_boring.swift
+++ b/Sources/_CryptoExtras/RSA/RSA_boring.swift
@@ -117,7 +117,7 @@ extension BoringSSLRSAPublicKey {
     internal func blind<H: HashFunction>(
         _ message: _RSA.BlindSigning.PreparedMessage,
         parameters: _RSA.BlindSigning.Parameters<H>
-    ) throws -> (blindedMessage: _RSA.BlindSigning.BlindedMessage, blindInverse: _RSA.BlindSigning.BlindInverse) {
+    ) throws -> (blindedMessage: Data, blindInverse: _RSA.BlindSigning.BlindInverse) {
         return try self.backing.blind(message, parameters: parameters)
     }
 
@@ -347,7 +347,7 @@ extension BoringSSLRSAPublicKey {
         fileprivate func blind<H: HashFunction>(
             _ message: _RSA.BlindSigning.PreparedMessage,
             parameters: _RSA.BlindSigning.Parameters<H>
-        ) throws -> (blindedMessage: _RSA.BlindSigning.BlindedMessage, blindInverse: _RSA.BlindSigning.BlindInverse) {
+        ) throws -> (blindedMessage: Data, blindInverse: _RSA.BlindSigning.BlindInverse) {
             /// ```
             /// All BN_CTX_get() calls must be made before calling any other functions that use the ctx as an argument.
             /// ...
@@ -439,7 +439,7 @@ extension BoringSSLRSAPublicKey {
             }
 
             // 12. output blinded_msg, inv
-            let blindedMessage = _RSA.BlindSigning.BlindedMessage(rawRepresentation: Data(blindedMessageBytes))
+            let blindedMessage = Data(blindedMessageBytes)
             var invBytes = [UInt8](repeating: 0, count: outputSize)
             guard CCryptoBoringSSL_BN_bn2bin_padded(&invBytes, outputSize, inv) == 1 else {
                 throw CryptoKitError.internalBoringSSLError()

--- a/Sources/_CryptoExtras/Util/RandomBytes.swift
+++ b/Sources/_CryptoExtras/Util/RandomBytes.swift
@@ -39,3 +39,15 @@ extension UnsafeMutableRawBufferPointer {
         }
     }
 }
+
+extension SystemRandomNumberGenerator {
+    @inlinable
+    static func randomBytes(count: Int) -> [UInt8] {
+        #if canImport(Darwin) || os(Linux) || os(Android) || os(Windows)
+        var rng = SystemRandomNumberGenerator()
+        return (0..<count).map { _ in rng.next() }
+        #else
+        fatalError("No secure random number generator on this platform.")
+        #endif
+    }
+}

--- a/Tests/_CryptoExtrasTests/TestRSABlindSigning.swift
+++ b/Tests/_CryptoExtrasTests/TestRSABlindSigning.swift
@@ -69,7 +69,7 @@ final class TestRSABlindSigning: XCTestCase {
                 let (blindedMessage, blindInverse) = try publicKey.blind(preparedMessage)
                 // NOTE: Sadly we can't validate the blinded message against the test vectors because BoringSSL doesn't
                 // have the APIs we would need to specify a fixed salt value.
-                XCTAssertEqual(blindedMessage.rawRepresentation.hexString.count, testVector.blinded_msg.count)
+                XCTAssertEqual(blindedMessage.hexString.count, testVector.blinded_msg.count)
                 XCTAssertEqual(blindInverse.rawRepresentation.hexString.count, testVector.inv.count)
             }
 
@@ -83,7 +83,7 @@ final class TestRSABlindSigning: XCTestCase {
                     qHexString: testVector.q,
                     parameters: testVector.parameters
                 )
-                let blindedMessage = try _RSA.BlindSigning.BlindedMessage(rawRepresentation: Data(hexString: testVector.blinded_msg))
+                let blindedMessage = try Data(hexString: testVector.blinded_msg)
                 let blindSignature = try privateKey.blindSignature(for: blindedMessage)
                 XCTAssertEqual(
                     blindSignature.rawRepresentation.hexString,
@@ -155,7 +155,7 @@ final class TestRSABlindSigning: XCTestCase {
         2950c126425538ad676e23a26c0f3e0523a307c557e3a6471771a5635b704c56
         """
         let privateKey = try _RSA.BlindSigning.PrivateKey(pemRepresentation: privateKeyPEM)
-        let blindedMessage = try _RSA.BlindSigning.BlindedMessage(rawRepresentation: Data(hexString: blindedMessageHexString))
+        let blindedMessage = try Data(hexString: blindedMessageHexString)
         XCTAssertThrowsError(try privateKey.blindSignature(for: blindedMessage)) { error in
             guard let error = error as? CryptoKitError, case .incorrectParameterSize = error else {
                 XCTFail("Unexpected error: \(error)")

--- a/Tests/_CryptoExtrasTests/TestRSABlindSigning.swift
+++ b/Tests/_CryptoExtrasTests/TestRSABlindSigning.swift
@@ -52,8 +52,9 @@ final class TestRSABlindSigning: XCTestCase {
         for testVector in testVectors {
             // Prepare
             do {
+                let publicKey = try _RSA.BlindSigning.PublicKey(nHexString: testVector.n, eHexString: testVector.e, parameters: testVector.parameters)
                 let message = try Data(hexString: testVector.msg)
-                let preparedMessage = _RSA.BlindSigning.prepare(message, parameters: testVector.parameters)
+                let preparedMessage = publicKey.prepare(message)
                 switch testVector.parameters.preparation {
                 case .identity:
                     XCTAssertEqual(preparedMessage.rawRepresentation, message)

--- a/Tests/_CryptoExtrasTests/TestRSABlindSigningAPI.swift
+++ b/Tests/_CryptoExtrasTests/TestRSABlindSigningAPI.swift
@@ -27,7 +27,7 @@ final class TestRSABlindSigningAPI: XCTestCase {
         let message = Data("This is some input data".utf8)
 
         // [Client] Prepare the message.
-        let preparedMessage = _RSA.BlindSigning.prepare(message, parameters: parameters)
+        let preparedMessage = publicKey.prepare(message)
 
         // [Client] Blind the message to send to the server and get its blinding inverse.
         let (blindedMessage, blindInverse) = try publicKey.blind(preparedMessage)

--- a/Tests/_CryptoExtrasTests/TestRSABlindSigningAPI.swift
+++ b/Tests/_CryptoExtrasTests/TestRSABlindSigningAPI.swift
@@ -29,14 +29,11 @@ final class TestRSABlindSigningAPI: XCTestCase {
         // [Client] Prepare the message.
         let preparedMessage = _RSA.BlindSigning.prepare(message, parameters: parameters)
 
-        // [Client] Blind the prepared message.
+        // [Client] Blind the message to send to the server and get its blinding inverse.
         let (blindedMessage, blindInverse) = try publicKey.blind(preparedMessage)
 
-        // [Client] Access the blinded message bytes for sending to the server.
-        let blindedMessageBytes = blindedMessage.rawRepresentation
-
         // [Issuer] Blind sign, construting the blinded message from the bytes received from the client.
-        let blindSignature = try privateKey.blindSignature(for: _RSA.BlindSigning.BlindedMessage(rawRepresentation: blindedMessageBytes))
+        let blindSignature = try privateKey.blindSignature(for: blindedMessage)
 
         // [Client] Finalize using the blind inverse to unblind the signature.
         let unblindedSignature = try publicKey.finalize(blindSignature, for: preparedMessage, blindInverse: blindInverse)

--- a/Tests/_CryptoExtrasTests/TestRSABlindSigningAPI.swift
+++ b/Tests/_CryptoExtrasTests/TestRSABlindSigningAPI.swift
@@ -1,0 +1,66 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCrypto open source project
+//
+// Copyright (c) 2024 Apple Inc. and the SwiftCrypto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of SwiftCrypto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import XCTest
+import Crypto
+import _CryptoExtras  // NOTE: No @testable import, because we want to test the public API.
+
+final class TestRSABlindSigningAPI: XCTestCase {
+    func testEndToEnd(parameters: _RSA.BlindSigning.Parameters<SHA384>, keySize: _RSA.Signing.KeySize) throws {
+        // [Issuer] Create key-pair (other initializers are available).
+        let privateKey = try _RSA.BlindSigning.PrivateKey(keySize: .bits2048, parameters: parameters)
+
+        // [Client] Create public key (other initializers are available).
+        let publicKey = privateKey.publicKey
+
+        // [Client] Have a message they wish to use.
+        let message = Data("This is some input data".utf8)
+
+        // [Client] Prepare the message.
+        let preparedMessage = _RSA.BlindSigning.prepare(message, parameters: parameters)
+
+        // [Client] Blind the prepared message.
+        let (blindedMessage, blindInverse) = try publicKey.blind(preparedMessage)
+
+        // [Client] Access the blinded message bytes for sending to the server.
+        let blindedMessageBytes = blindedMessage.rawRepresentation
+
+        // [Issuer] Blind sign, construting the blinded message from the bytes received from the client.
+        let blindSignature = try privateKey.blindSignature(for: _RSA.BlindSigning.BlindedMessage(rawRepresentation: blindedMessageBytes))
+
+        // [Client] Finalize using the blind inverse to unblind the signature.
+        let unblindedSignature = try publicKey.finalize(blindSignature, for: preparedMessage, blindInverse: blindInverse)
+
+        // [Verifier] Verify the unblinded signature.
+        XCTAssert(publicKey.isValidSignature(unblindedSignature, for: preparedMessage))
+    }
+
+    func testEndToEnd() throws {
+        let allNamedRFC9474Variants: [_RSA.BlindSigning.Parameters] = [
+            .RSABSSA_SHA384_PSSZERO_Deterministic,
+            .RSABSSA_SHA384_PSSZERO_Randomized,
+            .RSABSSA_SHA384_PSS_Deterministic,
+            .RSABSSA_SHA384_PSS_Randomized,
+        ]
+        let keySizes: [_RSA.Signing.KeySize] = [
+            .bits2048,
+            .bits3072,
+            .bits4096,
+        ]
+        for parameters in allNamedRFC9474Variants {
+            for keySize in keySizes {
+                try testEndToEnd(parameters: parameters, keySize: keySize)
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is building on https://github.com/apple/swift-crypto/pull/232 and adds the client operations.

Currently a draft PR to _that PR branch_ to show the incremental change.